### PR TITLE
Feature autopause

### DIFF
--- a/LuteBot/Config/PropertyItem.cs
+++ b/LuteBot/Config/PropertyItem.cs
@@ -23,7 +23,7 @@
         NoteCooldown,
         DebugMode,
         ZeroingOnPlay,
-        DontPlayNoteWhenRequired,
+        PauseWhenRequired,
 
         //keybinds
         Play,

--- a/LuteBot/IO/KB/ActionManager.cs
+++ b/LuteBot/IO/KB/ActionManager.cs
@@ -132,13 +132,11 @@ namespace LuteBot.IO.KB
             pci.cbSize = Marshal.SizeOf(typeof(CURSORINFO));
             GetCursorInfo(ref pci); // it stores the cursordata to the struct
 
-
-
             /*
              * If the cursor is showing, it means the user is typing or doesn't have the required state to play lute.
              */
 
-            if (ConfigManager.GetBooleanProperty(PropertyItem.DontPlayNoteWhenRequired) == true)
+            if (ConfigManager.GetBooleanProperty(PropertyItem.PauseWhenRequired) == true)
             {
                 if (pci.flags == CURSOR_SHOWING)
                 {

--- a/LuteBot/IO/KB/ActionManager.cs
+++ b/LuteBot/IO/KB/ActionManager.cs
@@ -128,40 +128,46 @@ namespace LuteBot.IO.KB
             if (winhandle != GetForegroundWindow()) // if the game has no focus, then fuck off
                 return;
 
+            /*
+             * If the cursor is showing, it has 2 possibilities:
+             * 
+             * 1. Console is still up from previously sent note
+             * 2. User initiated action (e.g., typing, menu)
+             * 
+             * To avoid case 1, we check again after brief timeout to give console enough time to close;
+             * if the cursor is still up, we know with high confidence it's case 2.
+             */
+
             CURSORINFO pci = new CURSORINFO();
             pci.cbSize = Marshal.SizeOf(typeof(CURSORINFO));
             GetCursorInfo(ref pci); // it stores the cursordata to the struct
-            if (ConfigManager.GetBooleanProperty(PropertyItem.PauseWhenRequired) == true)
+
+            if (pci.flags == CURSOR_SHOWING)
             {
-                /*
-                 * If the cursor is showing, it has 2 possibilities:
-                 * 
-                 * 1. Console is still up from previously sent note
-                 * 2. User initiated action (e.g., typing, menu)
-                 * 
-                 * To avoid case 1, we check again after brief timeout to give console enough time to close;
-                 * if the cursor is still up, we know with high confidence it's case 2.
-                 */
-                if (pci.flags == CURSOR_SHOWING)
+                Thread.Sleep(20);
+                // refetch cursor info
+                CURSORINFO pci_1 = new CURSORINFO();
+                pci_1.cbSize = Marshal.SizeOf(typeof(CURSORINFO));
+                GetCursorInfo(ref pci_1);
+                if (pci_1.flags == CURSOR_SHOWING)
                 {
-                    Thread.Sleep(20);
-                    CURSORINFO pci_1 = new CURSORINFO();
-                    pci_1.cbSize = Marshal.SizeOf(typeof(CURSORINFO));
-                    GetCursorInfo(ref pci_1); // it stores the cursordata to the struct
-                    if (pci_1.flags == CURSOR_SHOWING)
+                    if (ConfigManager.GetBooleanProperty(PropertyItem.PauseWhenRequired) == true)
                     {
                         PauseFromGameEvent(null, EventArgs.Empty);
-                        return;
                     }
-                }
-
-                if (((Control.ModifierKeys & Keys.Control) == Keys.Control) ||
-                    ((Control.ModifierKeys & Keys.Shift) == Keys.Shift) ||
-                    (Control.ModifierKeys & Keys.Alt) == Keys.Alt)
-                {
-                    PauseFromGameEvent(null, EventArgs.Empty);
                     return;
                 }
+            }
+
+            if (((Control.ModifierKeys & Keys.Control) == Keys.Control) ||
+                ((Control.ModifierKeys & Keys.Shift) == Keys.Shift) ||
+                (Control.ModifierKeys & Keys.Alt) == Keys.Alt)
+            {
+                if (ConfigManager.GetBooleanProperty(PropertyItem.PauseWhenRequired) == true)
+                {
+                    PauseFromGameEvent(null, EventArgs.Empty);
+                }
+                return;
             }
 
 

--- a/LuteBot/IO/KB/ActionManager.cs
+++ b/LuteBot/IO/KB/ActionManager.cs
@@ -117,12 +117,10 @@ namespace LuteBot.IO.KB
         private static extern IntPtr GetForegroundWindow();
         #endregion
 
-
-
+        public static event EventHandler PauseFromGameEvent = delegate { };
 
         private static void InputCommand(int noteId)
         {
-           
             Process[] processes = Process.GetProcessesByName("Mordhau-Win64-Shipping"); // i refresh it on each call because it may get closed or rebooted etc
             if (processes.Length != 1) // if there is no game detected then fuck off
                 return;
@@ -143,12 +141,18 @@ namespace LuteBot.IO.KB
             if (ConfigManager.GetBooleanProperty(PropertyItem.DontPlayNoteWhenRequired) == true)
             {
                 if (pci.flags == CURSOR_SHOWING)
+                {
+                    PauseFromGameEvent(null, EventArgs.Empty);
                     return;
+                }
 
                 if (((Control.ModifierKeys & Keys.Control) == Keys.Control) ||
                     ((Control.ModifierKeys & Keys.Shift) == Keys.Shift) ||
                     (Control.ModifierKeys & Keys.Alt) == Keys.Alt)
+                {
+                    PauseFromGameEvent(null, EventArgs.Empty);
                     return;
+                }
             }
 
 

--- a/LuteBot/Resources/DefaultConfig.txt
+++ b/LuteBot/Resources/DefaultConfig.txt
@@ -129,7 +129,7 @@
       "Value": "false"
     },
 	{
-      "Item": "DontPlayNoteWhenRequired",
+      "Item": "PauseWhenRequired",
       "Value": "true"
     }
   ]

--- a/LuteBot/UI/LuteBotForm.cs
+++ b/LuteBot/UI/LuteBotForm.cs
@@ -86,6 +86,7 @@ namespace LuteBot
             trackSelectionManager.ToggleTrackRequest += new EventHandler<TrackItem>(ToggleTrack);
             liveMidiManager = new LiveMidiManager();
             hotkeyManager.LiveInputManager = liveMidiManager;
+            ActionManager.PauseFromGameEvent += PauseFromGame;
 
             PlayButton.Enabled = false;
             StopButton.Enabled = false;
@@ -406,7 +407,11 @@ namespace LuteBot
             {
                 ActionManager.ToggleConsole(true);
             }
-            PlayButton.Text = playButtonStopString;
+            // needs to be wrapped to avoid cross-thread issue
+            PlayButton.BeginInvoke(new MethodInvoker(() =>
+            {
+                PlayButton.Text = playButtonStopString;
+            }));
             player.Play();
             timer1.Start();
             playButtonIsPlaying = true;
@@ -418,7 +423,11 @@ namespace LuteBot
             {
                 ActionManager.ToggleConsole(false);
             }
-            PlayButton.Text = playButtonStartString;
+            // needs to be wrapped to avoid cross-thread issue
+            PlayButton.BeginInvoke(new MethodInvoker(() =>
+            {
+                PlayButton.Text = playButtonStartString;
+            }));
             player.Pause();
             timer1.Stop();
             playButtonIsPlaying = false;
@@ -509,6 +518,12 @@ namespace LuteBot
                 trackSelectionForm.Left = coords.X;
             }
         }
+
+        private void PauseFromGame(object sender, EventArgs e)
+        {
+            Pause();
+        }
+
 
         private static IntPtr SetHook(LowLevelKeyboardProc proc)
         {

--- a/LuteBot/UI/SettingsForm.Designer.cs
+++ b/LuteBot/UI/SettingsForm.Designer.cs
@@ -54,7 +54,7 @@
             this.NoteCountLabel = new System.Windows.Forms.Label();
             this.LowestNoteLabel = new System.Windows.Forms.Label();
             this.LowestNoteNumeric = new System.Windows.Forms.NumericUpDown();
-            this.DontPlayWhenRequiredCheckbox = new System.Windows.Forms.CheckBox();
+            this.PauseWhenRequiredCheckbox = new System.Windows.Forms.CheckBox();
             this.SettingsGroupBox.SuspendLayout();
             this.AdvancedGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NoteCooldownNumeric)).BeginInit();
@@ -182,7 +182,7 @@
             // 
             // SettingsGroupBox
             // 
-            this.SettingsGroupBox.Controls.Add(this.DontPlayWhenRequiredCheckbox);
+            this.SettingsGroupBox.Controls.Add(this.PauseWhenRequiredCheckbox);
             this.SettingsGroupBox.Controls.Add(this.ZeroingCheckBox);
             this.SettingsGroupBox.Controls.Add(this.LiveMidiCheckBox);
             this.SettingsGroupBox.Controls.Add(this.OffAutoConsoleRadio);
@@ -354,16 +354,16 @@
             this.LowestNoteNumeric.TabIndex = 13;
             this.LowestNoteNumeric.ValueChanged += new System.EventHandler(this.LowestNoteNumeric_ValueChanged);
             // 
-            // DontPlayWhenRequiredCheckbox
+            // PauseWhenRequiredCheckbox
             // 
-            this.DontPlayWhenRequiredCheckbox.AutoSize = true;
-            this.DontPlayWhenRequiredCheckbox.Location = new System.Drawing.Point(6, 157);
-            this.DontPlayWhenRequiredCheckbox.Name = "DontPlayWhenRequiredCheckbox";
-            this.DontPlayWhenRequiredCheckbox.Size = new System.Drawing.Size(378, 17);
-            this.DontPlayWhenRequiredCheckbox.TabIndex = 8;
-            this.DontPlayWhenRequiredCheckbox.Text = "Dont play notes when a modifier key is pressed or when player is in a menu";
-            this.DontPlayWhenRequiredCheckbox.UseVisualStyleBackColor = true;
-            this.DontPlayWhenRequiredCheckbox.CheckedChanged += new System.EventHandler(this.DontPlayWhenRequiredCheckbox_CheckedChanged);
+            this.PauseWhenRequiredCheckbox.AutoSize = true;
+            this.PauseWhenRequiredCheckbox.Location = new System.Drawing.Point(6, 157);
+            this.PauseWhenRequiredCheckbox.Name = "PauseWhenRequiredCheckbox";
+            this.PauseWhenRequiredCheckbox.Size = new System.Drawing.Size(378, 17);
+            this.PauseWhenRequiredCheckbox.TabIndex = 8;
+            this.PauseWhenRequiredCheckbox.Text = "Pause when a modifier key is pressed or when player is in a menu";
+            this.PauseWhenRequiredCheckbox.UseVisualStyleBackColor = true;
+            this.PauseWhenRequiredCheckbox.CheckedChanged += new System.EventHandler(this.PauseWhenRequiredCheckbox_CheckedChanged);
             // 
             // SettingsForm
             // 
@@ -421,6 +421,6 @@
         private System.Windows.Forms.RadioButton OffAutoConsoleRadio;
         private System.Windows.Forms.CheckBox LiveMidiCheckBox;
         private System.Windows.Forms.CheckBox ZeroingCheckBox;
-        private System.Windows.Forms.CheckBox DontPlayWhenRequiredCheckbox;
+        private System.Windows.Forms.CheckBox PauseWhenRequiredCheckbox;
     }
 }

--- a/LuteBot/UI/SettingsForm.cs
+++ b/LuteBot/UI/SettingsForm.cs
@@ -120,7 +120,7 @@ namespace LuteBot
             OnlineSyncCheckBox.Checked = ConfigManager.GetBooleanProperty(PropertyItem.OnlineSync);
             SoundEffectsCheckBox.Checked = ConfigManager.GetBooleanProperty(PropertyItem.SoundEffects);
             ZeroingCheckBox.Checked = ConfigManager.GetBooleanProperty(PropertyItem.ZeroingOnPlay);
-            DontPlayWhenRequiredCheckbox.Checked = ConfigManager.GetBooleanProperty(PropertyItem.DontPlayNoteWhenRequired);
+            PauseWhenRequiredCheckbox.Checked = ConfigManager.GetBooleanProperty(PropertyItem.PauseWhenRequired);
             InitRadioButtons();
 
             NoteConversionMode.SelectedIndex = ConfigManager.GetIntegerProperty(PropertyItem.NoteConversionMode);
@@ -256,9 +256,9 @@ namespace LuteBot
             ConfigManager.SetProperty(PropertyItem.ZeroingOnPlay, (ZeroingCheckBox.Checked.ToString()));
         }
 
-        private void DontPlayWhenRequiredCheckbox_CheckedChanged(object sender, EventArgs e)
+        private void PauseWhenRequiredCheckbox_CheckedChanged(object sender, EventArgs e)
         {
-            ConfigManager.SetProperty(PropertyItem.DontPlayNoteWhenRequired, (DontPlayWhenRequiredCheckbox.Checked.ToString()));
+            ConfigManager.SetProperty(PropertyItem.PauseWhenRequired, (PauseWhenRequiredCheckbox.Checked.ToString()));
         }
     }
 }


### PR DESCRIPTION
Renamed `DontPlayNoteWhenRequired` to `PauseWhenRequired`, set to on by default.

If `PauseWhenRequired` is on, when conditions meet in game, the player will pause.
If `PauseWhenRequired` is off, when conditions meet in game, it will mute the player (basically how it was before).
I've removed the original behavior where it just breaks your game, because honestly I think there's nothing good about it.

Pausing is done by bubbling an event up `LuteBotForm.cs`, which when caught, is set to pause the player.

To solve the cursor issue giving false positives (since opening console to send notes also shows cursor), given that the console should close quickly, it uses a 2 check mechanism:
```python
if Cursor_Showing:
  timeout(20) # give time for console to close
  if Cursor_showing: # if it still shows after time out, it's likely user initiated event
    # pause/mute player
```

Note:
If `PauseWhenRequired` is off, if a fast song is playing (like through fire n flames), user won't be able to sprint for some reason, but they should still be able to open chat and type.